### PR TITLE
Minor fixes to suppress some make warnings

### DIFF
--- a/src/extendedjetexample.cxx
+++ b/src/extendedjetexample.cxx
@@ -179,7 +179,10 @@ int main(int argc, char* argv[]){
   vector<PseudoJet> TruthConstituents;
   vector<PseudoJet> SmearedConstituents;
 
-  for(long iEvent=0; iEvent<inTree->GetEntries(); iEvent++){
+  if(nevents < 0)
+    nevents = inTree->GetEntries();
+
+  for(long iEvent=0; iEvent<nevents; iEvent++){
     
     //Read next Event
     if(inTree->GetEntry(iEvent) <=0) break;
@@ -229,7 +232,7 @@ int main(int argc, char* argv[]){
     TruthConstituents.clear();
     SmearedConstituents.clear();
 
-    for(int j=0; j<inEventS->GetNTracks(); j++){
+    for(unsigned int j=0; j<inEventS->GetNTracks(); j++){
       // first three particles are always beam and the virtual photon. skip.
       if ( j<3) continue;
 


### PR DESCRIPTION
This PR introduces minor changes to fix some warning messages given by the `make` command that I found on RCF. The warning messages were:

```
src/jetspectra.cxx: In function 'int main(int, char**)':
src/jetspectra.cxx:167:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for(int j=0; j<inEventS->GetNTracks(); j++){
                                         ^
src/jetspectra.cxx:41:7: warning: variable 'nevents' set but not used [-Wunused-but-set-variable]
   int nevents = -1;
```

These should be fixed now by changing the `for` loop iterator to an unsigned int and by using `nevents` in the event loop rather than the default total number of events in the tree.